### PR TITLE
Added command to copy structures from save's structure folder

### DIFF
--- a/src/main/java/vazkii/pillar/Pillar.java
+++ b/src/main/java/vazkii/pillar/Pillar.java
@@ -28,6 +28,7 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
+import vazkii.pillar.command.CommandPillarCopy;
 import vazkii.pillar.command.CommandPillarReload;
 import vazkii.pillar.command.CommandPillarSpawn;
 
@@ -112,6 +113,7 @@ public class Pillar {
 	public void serverStarting(FMLServerStartingEvent event) {
 		event.registerServerCommand(new CommandPillarReload());
 		event.registerServerCommand(new CommandPillarSpawn());
+		event.registerServerCommand(new CommandPillarCopy());
 	}
 
 	public static void log(String m) {

--- a/src/main/java/vazkii/pillar/StructureLoader.java
+++ b/src/main/java/vazkii/pillar/StructureLoader.java
@@ -15,14 +15,17 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.google.common.cache.LoadingCache;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
-import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.storage.loot.LootTable;

--- a/src/main/java/vazkii/pillar/StructureLoader.java
+++ b/src/main/java/vazkii/pillar/StructureLoader.java
@@ -35,9 +35,9 @@ import vazkii.pillar.schema.StructureSchema;
 public final class StructureLoader {
 
 	public static final Map<String, StructureSchema> loadedSchemas = new HashMap();
-
+	
 	private static Gson gson = new GsonBuilder().setPrettyPrinting().create();
-
+	
 	public static void loadStructures(World world) {
 		Pillar.log("Loading structures...");
 		
@@ -126,5 +126,5 @@ public final class StructureLoader {
 	public static String jsonifySchema(StructureSchema schema) {
 		return gson.toJson(schema);
 	}
-
+	
 }

--- a/src/main/java/vazkii/pillar/StructureLoader.java
+++ b/src/main/java/vazkii/pillar/StructureLoader.java
@@ -15,29 +15,30 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.google.common.cache.LoadingCache;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
+import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import vazkii.pillar.schema.FillingType;
+import vazkii.pillar.schema.GeneratorType;
 import vazkii.pillar.schema.StructureSchema;
 
 public final class StructureLoader {
 
 	public static final Map<String, StructureSchema> loadedSchemas = new HashMap();
-	
+
 	private static Gson gson = new GsonBuilder().setPrettyPrinting().create();
-	
+	private static StructureSchema defaultSchema;
+
 	public static void loadStructures(World world) {
 		Pillar.log("Loading structures...");
 		
@@ -126,5 +127,41 @@ public final class StructureLoader {
 	public static String jsonifySchema(StructureSchema schema) {
 		return gson.toJson(schema);
 	}
-	
+
+	public static StructureSchema getDefaultSchema() {
+		if (defaultSchema != null)
+			return defaultSchema;
+
+		defaultSchema = new StructureSchema();
+		defaultSchema.generatorType = GeneratorType.NONE;
+		defaultSchema.minY = -1;
+		defaultSchema.maxY = -1;
+		defaultSchema.offsetX = 0;
+		defaultSchema.offsetY = 0;
+		defaultSchema.offsetZ = 0;
+
+		defaultSchema.mirrorType = "NONE";
+		defaultSchema.rotation = null;
+		defaultSchema.ignoreEntities = false;
+
+		defaultSchema.dimensionSpawns = Collections.emptyList();
+		defaultSchema.biomeNameSpawns = Collections.emptyList();
+		defaultSchema.biomeTagSpawns = Collections.emptyList();
+		defaultSchema.isDimensionSpawnsBlacklist = false;
+		defaultSchema.isBiomeNameSpawnsBlacklist = false;
+		defaultSchema.isBiomeTagSpawnsBlacklist = false;
+		defaultSchema.generateEverywhere = false;
+
+		defaultSchema.integrity = 1;
+		defaultSchema.decay = 0;
+
+		defaultSchema.filling = "";
+		defaultSchema.fillingMetadata = 0;
+		defaultSchema.fillingType = FillingType.AIR;
+
+		defaultSchema.rarity = 100;
+
+		return defaultSchema;
+	}
+
 }

--- a/src/main/java/vazkii/pillar/StructureLoader.java
+++ b/src/main/java/vazkii/pillar/StructureLoader.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +30,6 @@ import net.minecraft.world.World;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
-import vazkii.pillar.schema.FillingType;
-import vazkii.pillar.schema.GeneratorType;
 import vazkii.pillar.schema.StructureSchema;
 
 public final class StructureLoader {
@@ -40,7 +37,6 @@ public final class StructureLoader {
 	public static final Map<String, StructureSchema> loadedSchemas = new HashMap();
 
 	private static Gson gson = new GsonBuilder().setPrettyPrinting().create();
-	private static StructureSchema defaultSchema;
 
 	public static void loadStructures(World world) {
 		Pillar.log("Loading structures...");
@@ -129,42 +125,6 @@ public final class StructureLoader {
 	
 	public static String jsonifySchema(StructureSchema schema) {
 		return gson.toJson(schema);
-	}
-
-	public static StructureSchema getDefaultSchema() {
-		if (defaultSchema != null)
-			return defaultSchema;
-
-		defaultSchema = new StructureSchema();
-		defaultSchema.generatorType = GeneratorType.NONE;
-		defaultSchema.minY = -1;
-		defaultSchema.maxY = -1;
-		defaultSchema.offsetX = 0;
-		defaultSchema.offsetY = 0;
-		defaultSchema.offsetZ = 0;
-
-		defaultSchema.mirrorType = "NONE";
-		defaultSchema.rotation = null;
-		defaultSchema.ignoreEntities = false;
-
-		defaultSchema.dimensionSpawns = Collections.emptyList();
-		defaultSchema.biomeNameSpawns = Collections.emptyList();
-		defaultSchema.biomeTagSpawns = Collections.emptyList();
-		defaultSchema.isDimensionSpawnsBlacklist = false;
-		defaultSchema.isBiomeNameSpawnsBlacklist = false;
-		defaultSchema.isBiomeTagSpawnsBlacklist = false;
-		defaultSchema.generateEverywhere = false;
-
-		defaultSchema.integrity = 1;
-		defaultSchema.decay = 0;
-
-		defaultSchema.filling = "";
-		defaultSchema.fillingMetadata = 0;
-		defaultSchema.fillingType = FillingType.AIR;
-
-		defaultSchema.rarity = 100;
-
-		return defaultSchema;
 	}
 
 }

--- a/src/main/java/vazkii/pillar/command/CommandPillarCopy.java
+++ b/src/main/java/vazkii/pillar/command/CommandPillarCopy.java
@@ -2,11 +2,11 @@
  * This class was created by <TehNut>. It's distributed as
  * part of the Pillar Mod. Get the Source Code in github:
  * https://github.com/Vazkii/Pillar
- * <p>
+ *
  * Pillar is Open Source and distributed under the
  * [ADD-LICENSE-HERE]
- * <p>
- * File Created @ [25/06/2016, 21:09:43 (GMT)]
+ *
+ * File Created @ [26/06/2016, 15:14:28 (GMT)]
  */
 package vazkii.pillar.command;
 

--- a/src/main/java/vazkii/pillar/command/CommandPillarCopy.java
+++ b/src/main/java/vazkii/pillar/command/CommandPillarCopy.java
@@ -2,10 +2,10 @@
  * This class was created by <TehNut>. It's distributed as
  * part of the Pillar Mod. Get the Source Code in github:
  * https://github.com/Vazkii/Pillar
- *
+ * <p>
  * Pillar is Open Source and distributed under the
  * [ADD-LICENSE-HERE]
- *
+ * <p>
  * File Created @ [25/06/2016, 21:09:43 (GMT)]
  */
 package vazkii.pillar.command;
@@ -25,33 +25,35 @@ import vazkii.pillar.Pillar;
 import vazkii.pillar.StructureLoader;
 
 import javax.annotation.Nullable;
-import java.io.*;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class CommandPillarCopy extends CommandBase {
 
-    private static final FileFilter NBT_FILTER = (FileFilter) FileFilterUtils.suffixFileFilter(".nbt");
+	private static final FileFilter NBT_FILTER = (FileFilter) FileFilterUtils.suffixFileFilter(".nbt");
 
-    @Override
-    public String getCommandName() {
-        return "pillar-copy";
-    }
+	@Override
+	public String getCommandName() {
+		return "pillar-copy";
+	}
 
-    @Override
-    public String getCommandUsage(ICommandSender sender) {
-        return "pillar-copy <sourceFile>";
-    }
+	@Override
+	public String getCommandUsage(ICommandSender sender) {
+		return "pillar-copy <sourceFile>";
+	}
 
-    @Override
-    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-        try {
-            if (args.length > 0) {
-                File structureFolder = server.getActiveAnvilConverter().getFile(server.getFolderName(), "structures");
-                if (!structureFolder.exists() || structureFolder.isFile()) {
-                    sender.addChatMessage(new TextComponentString("The world's structure folder could not be found.").setStyle(new Style().setColor(TextFormatting.RED)));
-                    return;
-                }
+	@Override
+	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+		try {
+			if (args.length > 0) {
+				File structureFolder = server.getActiveAnvilConverter().getFile(server.getFolderName(), "structures");
+				if (!structureFolder.exists() || structureFolder.isFile()) {
+					throw new CommandException("The world's structure folder could not be found.");
+				}
 
 				String requestedName = "";
 				if (args.length != 1)
@@ -60,44 +62,44 @@ public class CommandPillarCopy extends CommandBase {
 				else
 					requestedName = args[0];
 
-                File[] structures = structureFolder.listFiles(NBT_FILTER);
-                for (File file : structures) {
+				File[] structures = structureFolder.listFiles(NBT_FILTER);
+				for (File file : structures) {
 					String fileName = file.getName();
-                    if (fileName.equalsIgnoreCase(requestedName + ".nbt")) {
-                        FileUtils.copyFileToDirectory(file, Pillar.structureDir);
-						File jsonFile = new File(Pillar.pillarDir, fileName.replace(".nbt", ".json"));
+					if (fileName.equalsIgnoreCase(requestedName + ".nbt")) {
+						FileUtils.copyFileToDirectory(file, Pillar.structureDir);
+						File jsonFile = new File(Pillar.pillarDir, fileName.replaceAll("\\.nbt$", ".json"));
 						if (!jsonFile.exists()) {
 							String schemaJson = StructureLoader.jsonifySchema(StructureLoader.getDefaultSchema());
 							FileWriter fileWriter = new FileWriter(jsonFile);
 							fileWriter.write(schemaJson);
 							fileWriter.close();
 						}
-						sender.addChatMessage(new TextComponentString("Successfully copied structure '" + fileName.replace(".nbt", "") + "'").setStyle(new Style().setColor(TextFormatting.GREEN)));
+						sender.addChatMessage(new TextComponentString("Successfully copied structure '" + fileName.replaceAll("\\.nbt$", "") + "'").setStyle(new Style().setColor(TextFormatting.GREEN)));
 						return;
-                    }
-                }
+					}
+				}
 
-				sender.addChatMessage(new TextComponentString("No structure file by that name was found!").setStyle(new Style().setColor(TextFormatting.RED)));
-            } else {
+				throw new CommandException("No structure file by that name was found!");
+			} else {
 				throw new WrongUsageException("/" + getCommandUsage(sender));
 			}
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
-    @Override
-    public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos) {
+	@Override
+	public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos) {
 		if (args.length == 1) {
 			List<String> files = new ArrayList<>();
 			File structureFolder = server.getActiveAnvilConverter().getFile(server.getFolderName(), "structures");
 			File[] structures = structureFolder.listFiles(NBT_FILTER);
 			for (File structure : structures)
-				files.add(structure.getName().replace(".nbt", ""));
+				files.add(structure.getName().replaceAll("\\.nbt$", ""));
 
 			return getListOfStringsMatchingLastWord(args, files);
 		}
-        return super.getTabCompletionOptions(server, sender, args, pos);
-    }
+		return super.getTabCompletionOptions(server, sender, args, pos);
+	}
 
 }

--- a/src/main/java/vazkii/pillar/command/CommandPillarCopy.java
+++ b/src/main/java/vazkii/pillar/command/CommandPillarCopy.java
@@ -19,16 +19,13 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
+import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import vazkii.pillar.Pillar;
-import vazkii.pillar.StructureLoader;
 
 import javax.annotation.Nullable;
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -69,10 +66,17 @@ public class CommandPillarCopy extends CommandBase {
 						FileUtils.copyFileToDirectory(file, Pillar.structureDir);
 						File jsonFile = new File(Pillar.pillarDir, fileName.replaceAll("\\.nbt$", ".json"));
 						if (!jsonFile.exists()) {
-							String schemaJson = StructureLoader.jsonifySchema(StructureLoader.getDefaultSchema());
-							FileWriter fileWriter = new FileWriter(jsonFile);
-							fileWriter.write(schemaJson);
-							fileWriter.close();
+							try {
+								jsonFile.createNewFile();
+								InputStream inStream = Pillar.class.getResourceAsStream("/assets/pillar/" + Pillar.TEMPLATE_FILE);
+								System.out.println(inStream);
+								OutputStream outStream = new FileOutputStream(jsonFile);
+								IOUtils.copy(inStream, outStream);
+								inStream.close();
+								outStream.close();
+							} catch (IOException e) {
+								e.printStackTrace();
+							}
 						}
 						sender.addChatMessage(new TextComponentString("Successfully copied structure '" + fileName.replaceAll("\\.nbt$", "") + "'").setStyle(new Style().setColor(TextFormatting.GREEN)));
 						return;

--- a/src/main/java/vazkii/pillar/command/CommandPillarCopy.java
+++ b/src/main/java/vazkii/pillar/command/CommandPillarCopy.java
@@ -1,0 +1,103 @@
+/**
+ * This class was created by <TehNut>. It's distributed as
+ * part of the Pillar Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Pillar
+ *
+ * Pillar is Open Source and distributed under the
+ * [ADD-LICENSE-HERE]
+ *
+ * File Created @ [25/06/2016, 21:09:43 (GMT)]
+ */
+package vazkii.pillar.command;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.Style;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import vazkii.pillar.Pillar;
+import vazkii.pillar.StructureLoader;
+
+import javax.annotation.Nullable;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CommandPillarCopy extends CommandBase {
+
+    private static final FileFilter NBT_FILTER = (FileFilter) FileFilterUtils.suffixFileFilter(".nbt");
+
+    @Override
+    public String getCommandName() {
+        return "pillar-copy";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "pillar-copy <sourceFile>";
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        try {
+            if (args.length > 0) {
+                File structureFolder = server.getActiveAnvilConverter().getFile(server.getFolderName(), "structures");
+                if (!structureFolder.exists() || structureFolder.isFile()) {
+                    sender.addChatMessage(new TextComponentString("The world's structure folder could not be found.").setStyle(new Style().setColor(TextFormatting.RED)));
+                    return;
+                }
+
+				String requestedName = "";
+				if (args.length != 1)
+					for (String arg : args)
+						requestedName += (requestedName.length() > 0 ? " " : "") + arg;
+				else
+					requestedName = args[0];
+
+                File[] structures = structureFolder.listFiles(NBT_FILTER);
+                for (File file : structures) {
+					String fileName = file.getName();
+                    if (fileName.equalsIgnoreCase(requestedName + ".nbt")) {
+                        FileUtils.copyFileToDirectory(file, Pillar.structureDir);
+						File jsonFile = new File(Pillar.pillarDir, fileName.replace(".nbt", ".json"));
+						if (!jsonFile.exists()) {
+							String schemaJson = StructureLoader.jsonifySchema(StructureLoader.getDefaultSchema());
+							FileWriter fileWriter = new FileWriter(jsonFile);
+							fileWriter.write(schemaJson);
+							fileWriter.close();
+						}
+						sender.addChatMessage(new TextComponentString("Successfully copied structure '" + fileName.replace(".nbt", "") + "'").setStyle(new Style().setColor(TextFormatting.GREEN)));
+						return;
+                    }
+                }
+
+				sender.addChatMessage(new TextComponentString("No structure file by that name was found!").setStyle(new Style().setColor(TextFormatting.RED)));
+            } else {
+				throw new WrongUsageException("/" + getCommandUsage(sender));
+			}
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos) {
+		if (args.length == 1) {
+			List<String> files = new ArrayList<>();
+			File structureFolder = server.getActiveAnvilConverter().getFile(server.getFolderName(), "structures");
+			File[] structures = structureFolder.listFiles(NBT_FILTER);
+			for (File structure : structures)
+				files.add(structure.getName().replace(".nbt", ""));
+
+			return getListOfStringsMatchingLastWord(args, files);
+		}
+        return super.getTabCompletionOptions(server, sender, args, pos);
+    }
+
+}

--- a/src/main/resources/assets/pillar/_template.json
+++ b/src/main/resources/assets/pillar/_template.json
@@ -5,7 +5,7 @@
 // ===================================================================
 
 {
-	"generatorType": "",
+	"generatorType": "NONE",
 	"minY": -1,
 	"maxY": -1,
 	"offsetX": 0,
@@ -31,5 +31,5 @@
 	"fillingMetadata": 0,
 	"fillingType": "AIR",
 	
-	"rarity": 100,
+	"rarity": 100
 }


### PR DESCRIPTION
* Overwrites files of the same name in the Pillar schematics folder. Does not overwrite existing JSON files. Useful for updating a structure, but keeping your configuration.
* Allows tab completion through server structure files.
* Tab completion is a bit wonky when the file has spaces in it. However, copying the file itself works fine.
* Tested and works on both server and client worlds.

I agree to whatever license you choose to place this project under. Feel free to change the header of `CommandPillarCopy` as you see fit.